### PR TITLE
Enable key separation when multiple CRDB clusters are run in the same namespace

### DIFF
--- a/request-cert/.gitignore
+++ b/request-cert/.gitignore
@@ -1,1 +1,2 @@
+.idea
 request-cert

--- a/request-cert/k8s_certificates.go
+++ b/request-cert/k8s_certificates.go
@@ -92,12 +92,12 @@ func getKubernetesCertificate(csrName string, csr []byte, wantServerAuth bool, a
 	}
 
 	fmt.Printf("Sending create request: %s for %s\n", req.Name, *addresses)
-	resp, err := client.Certificates().CertificateSigningRequests().Create(req)
+	resp, err := client.CertificatesV1beta1().CertificateSigningRequests().Create(req)
 
 	if err != nil && k8s_errors.IsAlreadyExists(err) && allowPrevious {
 		fmt.Printf("Attempting to use previous CSR: %s\n", req.Name)
 		getOpts := types.GetOptions{TypeMeta: types.TypeMeta{Kind: "CertificateSigningRequest"}}
-		resp, err = client.Certificates().CertificateSigningRequests().Get(req.Name, getOpts)
+		resp, err = client.CertificatesV1beta1().CertificateSigningRequests().Get(req.Name, getOpts)
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "CertificateSigningRequest.Create(%s) failed", req.Name)
@@ -113,7 +113,7 @@ func getKubernetesCertificate(csrName string, csr []byte, wantServerAuth bool, a
 		FieldSelector:  fields.OneTermEqualSelector("metadata.name", csrName).String(),
 	}
 
-	resultCh, err := client.Certificates().CertificateSigningRequests().Watch(watchReq)
+	resultCh, err := client.CertificatesV1beta1().CertificateSigningRequests().Watch(watchReq)
 	if err != nil {
 		return nil, errors.Wrapf(err, "CertificateSigningRequest.Watch(%s) failed: %v", csrName)
 	}
@@ -190,7 +190,7 @@ func getSecrets(secretName string) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	secret, err := client.Core().Secrets(*namespace).Get(secretName, types.GetOptions{})
+	secret, err := client.CoreV1().Secrets(*namespace).Get(secretName, types.GetOptions{})
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			return nil, nil, nil

--- a/request-cert/main.go
+++ b/request-cert/main.go
@@ -40,7 +40,7 @@ var (
 	addresses       = flag.String("addresses", "", "comma-separated list of DNS names and IP addresses for node certificate")
 	user            = flag.String("user", "", "username for client certificate")
 
-	cluster			= flag.String("cluster", "", "logical cluster name distinguishing it from other clusters in the same namespace")
+	cluster         = flag.String("cluster", "", "logical cluster name distinguishing it from other clusters in the same namespace")
 	namespace       = flag.String("namespace", "", "kubernetes namespace for this pod")
 	certsDir        = flag.String("certs-dir", "cockroach-certs", "certs directory")
 	keySize         = flag.Int("key-size", 4096, "RSA key size in bits")

--- a/request-cert/main.go
+++ b/request-cert/main.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-// Author: Marc berhault (marc@cockroachlabs.com)
+// Author: Marc Berhault (marc@cockroachlabs.com)
 
 package main
 
@@ -37,22 +37,28 @@ import (
 var (
 	certificateType = flag.String("type", "", "certificate type: node or client")
 
-	addresses = flag.String("addresses", "", "comma-separated list of DNS names and IP addresses for node certificate")
-	user      = flag.String("user", "", "username for client certificate")
+	addresses       = flag.String("addresses", "", "comma-separated list of DNS names and IP addresses for node certificate")
+	user            = flag.String("user", "", "username for client certificate")
 
+	cluster			= flag.String("cluster", "", "logical cluster name distinguishing it from other clusters in the same namespace")
 	namespace       = flag.String("namespace", "", "kubernetes namespace for this pod")
 	certsDir        = flag.String("certs-dir", "cockroach-certs", "certs directory")
-	keySize         = flag.Int("key-size", 2048, "RSA key size in bits")
+	keySize         = flag.Int("key-size", 4096, "RSA key size in bits")
 	symlinkCASource = flag.String("symlink-ca-from", "", "if non-empty, create <certs-dir>/ca.crt linking to this file")
 )
 
 func main() {
 	flag.Parse()
-	flag.Lookup("logtostderr").Value.Set("true")
 
 	// Validate flags.
 	if len(*namespace) == 0 {
 		log.Fatal("--namespace is required and must not be empty")
+	}
+
+	if len(*cluster) > 0 {
+		if strings.Contains(*cluster, " ") {
+			log.Fatal("cluster cannot contain spaces")
+		}
 	}
 
 	// Check certificate type.
@@ -75,7 +81,12 @@ func main() {
 		// Certificate name for nodes must include a node identifier. We use the hostname.
 		// The CSR name is the same.
 		filename = "node"
-		csrName = *namespace + "." + filename + "." + hostname
+		if len(*cluster) == 0 {
+			csrName = *namespace + "." + filename + "." + hostname
+		} else {
+			csrName = *namespace + "." + *cluster + "." + filename + "." + hostname
+		}
+
 		wantServerAuth = true
 	case "client":
 		if len(*user) == 0 {
@@ -86,7 +97,12 @@ func main() {
 		// Certificate name for clients must only include the username.
 		// Include the hostname in the CSR name.
 		filename = "client." + *user
-		csrName = *namespace + "." + filename
+		if len(*cluster) == 0 {
+			csrName = *namespace + "." + filename
+		} else {
+			csrName = *namespace + "." + *cluster + "." + filename
+		}
+
 	default:
 		log.Fatalf("unknown certificate type requested: --type=%q. Valid types are \"node\", \"client\"", *certificateType)
 	}
@@ -168,6 +184,7 @@ func serverCSR(hosts []string) *x509.CertificateRequest {
 		Subject: pkix.Name{
 			Organization: []string{"Cockroach"},
 			CommonName:   "node",
+
 		},
 	}
 


### PR DESCRIPTION
Currently node and client keys are visible between CRDB clusters running in the same namespace.

This pull request adds a -cluster flag to logically name and partition the key-space.  If the -cluster flag is not specified everything works as before.

Example:

```
/request-cert '-namespace=crdb' '-certs-dir=/cockroach-certs' '-type=client' '-user=root' '-symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt' '-cluster=crdb-test'
2019/02/27 16:21:07 Looking up cert and key under secret crdb.crdb-test.client.root
W0227 16:21:07.014788       1 client_config.go:549] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2019/02/27 16:21:07 Secret crdb.crdb-test.client.root not found, sending CSR
Sending create request: crdb.crdb-test.client.root for 
Request sent, waiting for approval. To approve, run 'kubectl certificate approve crdb.crdb-test.client.root'
CSR approved, but no certificate in response. Waiting some more
request crdb.crdb-test.client.root Approved at 2019-02-27 16:21:09 +0000 UTC
  reason:   AutoApproved
  message:  Auto approving CockroachDB certificate after SubjectAccessReview.
2019/02/27 16:21:09 Storing cert and key under secret crdb.crdb-test.client.root
2019/02/27 16:21:09 Writing cert and key to local files
wrote key file: /cockroach-certs/client.root.key
wrote certificate file: /cockroach-certs/client.root.crt
symlinked CA certificate file: /cockroach-certs/ca.crt -> /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
```