### PR TITLE
fix Certificates and Core api version

### DIFF
--- a/request-cert/k8s_certificates.go
+++ b/request-cert/k8s_certificates.go
@@ -92,12 +92,12 @@ func getKubernetesCertificate(csrName string, csr []byte, wantServerAuth bool, a
 	}
 
 	fmt.Printf("Sending create request: %s for %s\n", req.Name, *addresses)
-	resp, err := client.Certificates().CertificateSigningRequests().Create(req)
+	resp, err := client.CertificatesV1beta1().CertificateSigningRequests().Create(req)
 
 	if err != nil && k8s_errors.IsAlreadyExists(err) && allowPrevious {
 		fmt.Printf("Attempting to use previous CSR: %s\n", req.Name)
 		getOpts := types.GetOptions{TypeMeta: types.TypeMeta{Kind: "CertificateSigningRequest"}}
-		resp, err = client.Certificates().CertificateSigningRequests().Get(req.Name, getOpts)
+		resp, err = client.CertificatesV1beta1().CertificateSigningRequests().Get(req.Name, getOpts)
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "CertificateSigningRequest.Create(%s) failed", req.Name)
@@ -113,7 +113,7 @@ func getKubernetesCertificate(csrName string, csr []byte, wantServerAuth bool, a
 		FieldSelector:  fields.OneTermEqualSelector("metadata.name", csrName).String(),
 	}
 
-	resultCh, err := client.Certificates().CertificateSigningRequests().Watch(watchReq)
+	resultCh, err := client.CertificatesV1beta1().CertificateSigningRequests().Watch(watchReq)
 	if err != nil {
 		return nil, errors.Wrapf(err, "CertificateSigningRequest.Watch(%s) failed: %v", csrName)
 	}
@@ -190,7 +190,7 @@ func getSecrets(secretName string) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	secret, err := client.Core().Secrets(*namespace).Get(secretName, types.GetOptions{})
+	secret, err := client.CoreV1().Secrets(*namespace).Get(secretName, types.GetOptions{})
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			return nil, nil, nil


### PR DESCRIPTION
Fix below error when you try `go get ./...`

```
$ go get ./...
# k8s/request-cert
./k8s_certificates.go:95:21: client.Certificates undefined (type *kubernetes.Clientset has no field or method Certificates)
./k8s_certificates.go:100:21: client.Certificates undefined (type *kubernetes.Clientset has no field or method Certificates)
./k8s_certificates.go:116:25: client.Certificates undefined (type *kubernetes.Clientset has no field or method Certificates)
./k8s_certificates.go:125:18: select case must be receive, send or assign recv
./k8s_certificates.go:193:23: client.Core undefined (type *kubernetes.Clientset has no field or method Core)

```