### PR TITLE
Correctly use flag.Args

### DIFF
--- a/locality-checker/main.go
+++ b/locality-checker/main.go
@@ -18,12 +18,12 @@ func main() {
 
 	ctx := context.Background()
 
-	var localityMountPath string
-	if len(flag.Args()) == 2 {
-		localityMountPath = flag.Args()[1]
-	} else {
-		localityMountPath = defaultLocalityMountPath
+	localityMountPath := defaultLocalityMountPath
+	if flag.Arg(0) != "" {
+		localityMountPath = flag.Arg(0)
 	}
+
+	log.Printf("writing locality information to %s", localityMountPath)
 
 	nodeName := os.Getenv("KUBERNETES_NODE")
 	if nodeName == "" {


### PR DESCRIPTION
  flag.Args removes argv[0] from it's list. To correctly search for
  positional arguments one must look at index 0 rather than skipping the
  first.