### PR TITLE
locality-checker: switch from positional parameter to -dest flag

### DIFF
--- a/locality-checker/main.go
+++ b/locality-checker/main.go
@@ -11,19 +11,13 @@ import (
 
 const defaultLocalityMountPath = "/etc/cockroach-locality"
 
-var prefix = flag.String("prefix", "", "prefix")
+var prefix = flag.String("prefix", "", "string prepended to --locality and --az flags")
+var dest = flag.String("dest", defaultLocalityMountPath, "directory to which files are written")
 
 func main() {
 	flag.Parse()
 
 	ctx := context.Background()
-
-	var localityMountPath string
-	if len(flag.Args()) == 2 {
-		localityMountPath = flag.Args()[1]
-	} else {
-		localityMountPath = defaultLocalityMountPath
-	}
 
 	nodeName := os.Getenv("KUBERNETES_NODE")
 	if nodeName == "" {
@@ -37,7 +31,7 @@ func main() {
 	l := kubernetes.LocalityChecker{
 		Clientset:            clientset,
 		NodeName:             nodeName,
-		WritePath:            localityMountPath,
+		WritePath:            *dest,
 		ErrorOnMissingLabels: errorOnMissingLabels == "1",
 		Prefix:               *prefix,
 	}


### PR DESCRIPTION
Previously, using the locality-checker like this:

```
locality-checker /etc/cockroach-env --prefix=aws-
```

caused this error:

```
error writing locality: open --prefix=aws-/region: no such file or directory
```

This patch fixes a positional parameter parsing bug by using only flag parameters.